### PR TITLE
Add Windows version of scripts

### DIFF
--- a/src/package.json.jinja
+++ b/src/package.json.jinja
@@ -16,7 +16,18 @@
     "build:all": "npm-run-all prestart build",
     "postbuild": "python3 utils/postbuild.py",
     "wikisync": "python3.7 wikisync.py",
-    "publish": "npm-run-all build:all wikisync"
+    "publish": "npm-run-all build:all wikisync",
+    "preprocess:win": "python utils/preprocess.py",
+    "nav:win": "python utils/nav.py",
+    "citations:win": "python utils/citations.py",
+    "custom_tests:win": "python utils/test.py",
+    "server:win": "webpack-dev-server --config webpack.development.js --open --host 0.0.0.0",
+    "start:win": "npm-run-all preprocess:win nav:win citations:win custom_tests:win server:win",
+    "build:win": "webpack --config webpack.production.js",
+    "build:all:win": "npm-run-all prestart:win build:win",
+    "postbuild:win": "python utils/postbuild.py",
+    "wikisync:win": "python wikisync.py",
+    "publish:win": "npm-run-all build:all:win wikisync:win"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Add Windows versions of scripts to `package.json.jinja` to avoid the `python/python3` error. Includes the `start:win` ones you added and new ones for `build:win`.